### PR TITLE
fix: model breakage and nomenclature

### DIFF
--- a/actions/addContract.ts
+++ b/actions/addContract.ts
@@ -136,7 +136,7 @@ export async function _registerNewOrder(
  * @param owner to add the conditional order to
  * @param params for the conditional order
  * @param proof for the conditional order (if it is part of a merkle root)
- * @param address address of the contract that emitted the event
+ * @param composableCow address of the contract that emitted the event
  * @param registry of all conditional orders
  */
 export const add = async (
@@ -144,7 +144,7 @@ export const add = async (
   owner: Owner,
   params: IConditionalOrder.ConditionalOrderParamsStruct,
   proof: Proof | null,
-  address: string,
+  composableCow: string,
   registry: Registry
 ) => {
   const { handler, salt, staticInput } = params;
@@ -171,7 +171,7 @@ export const add = async (
         params,
         proof,
         orders: new Map(),
-        address,
+        composableCow,
       });
     }
   } else {
@@ -181,7 +181,7 @@ export const add = async (
     );
     registry.ownerOrders.set(
       owner,
-      new Set([{ tx, params, proof, orders: new Map(), address }])
+      new Set([{ tx, params, proof, orders: new Map(), composableCow }])
     );
   }
 };

--- a/actions/addContract.ts
+++ b/actions/addContract.ts
@@ -14,7 +14,7 @@ import type {
 } from "./types/ComposableCoW";
 import { ComposableCoW__factory } from "./types/factories/ComposableCoW__factory";
 
-import { isCompatible, handleExecutionError, init, writeRegistry } from "./utils";
+import { isComposableCowCompatible, handleExecutionError, init, writeRegistry } from "./utils";
 import { ChainContext, Owner, Proof, Registry } from "./model";
 
 /**
@@ -45,7 +45,7 @@ const _addContract: ActionFn = async (context: Context, event: Event) => {
     // Do not process logs that are not from a `ComposableCoW`-compatible contract
     // This is a *normal* case, if the contract is not `ComposableCoW`-compatible
     // then we do not need to do anything, and therefore don't flag as an error.
-    if (!isCompatible(await provider.getCode(log.address))) {
+    if (!isComposableCowCompatible(await provider.getCode(log.address))) {
       continue;
     }
     const { error } = await _registerNewOrder(tx, log, composableCow, registry);

--- a/actions/checkForAndPlaceOrder.ts
+++ b/actions/checkForAndPlaceOrder.ts
@@ -72,7 +72,7 @@ const _checkForAndPlaceOrder: ActionFn = async (
         conditionalOrder.params
       );
       const contract = ComposableCoW__factory.connect(
-        conditionalOrder.address,
+        conditionalOrder.composableCow,
         chainContext.provider
       );
 

--- a/actions/model.ts
+++ b/actions/model.ts
@@ -50,7 +50,7 @@ export type ConditionalOrder = {
   // a map of discrete order hashes to their status
   orders: Map<OrderUid, OrderStatus>;
   // the address to poll for orders (may, or **may not** be `ComposableCoW`)
-  address: string;
+  composableCow: string;
 };
 
 /**

--- a/actions/utils.spec.ts
+++ b/actions/utils.spec.ts
@@ -1,14 +1,18 @@
 import * as composableCow from './artifacts/ComposableCoW.json'
 import * as extensibleFallbackHandler from './artifacts/ExtensibleFallbackHandler.json'
-import { isCompatible } from './utils'
+import { isComposableCowCompatible } from './utils'
+
+// consts for readability
+const composableCowBytecode = composableCow.deployedBytecode.object
+const failBytecode = extensibleFallbackHandler.deployedBytecode.object
 
 describe('test supports composable cow interface from bytecode', () => {
     it('should pass', () => {
-        expect(isCompatible(composableCow.deployedBytecode.object)).toBe(true)
+        expect(isComposableCowCompatible(composableCowBytecode)).toBe(true)
     })
 
     it('should fail', () => {
-        expect(isCompatible(extensibleFallbackHandler.deployedBytecode.object)).toBe(false)
+        expect(isComposableCowCompatible(failBytecode)).toBe(false)
     })
 })
 
@@ -16,17 +20,17 @@ describe('test against concrete examples', () => {
     const signatures = ['0x1c7662c8', '0x26e0a196']
 
     it('should pass with both selectors', () => {
-        expect(isCompatible('0x1c7662c826e0a196')).toBe(true)
+        expect(isComposableCowCompatible('0x1c7662c826e0a196')).toBe(true)
     })
 
     // using `forEach` here, be careful not to do async tests.
     signatures.forEach((s) => {
         it(`should fail with only selector ${s}`, () => {
-            expect(isCompatible(s)).toBe(false)
+            expect(isComposableCowCompatible(s)).toBe(false)
         })
     })
 
     it('should fail with no selectors', () => {
-        expect(isCompatible('0xdeadbeefdeadbeef')).toBe(false)
+        expect(isComposableCowCompatible('0xdeadbeefdeadbeef')).toBe(false)
     })
 })

--- a/actions/utils.ts
+++ b/actions/utils.ts
@@ -351,7 +351,7 @@ export function sendSlack(message: string): boolean {
  * @param code the contract's deployed bytecode as a hex string
  * @returns A boolean indicating if the contract likely implements the interface
  */
-export function isCompatible(code: string): boolean {
+export function isComposableCowCompatible(code: string): boolean {
   const composableCow = ComposableCoW__factory.createInterface();
 
   return REQUIRED_SELECTORS.every((signature) => {


### PR DESCRIPTION
**Overview**

This PR:

1. Fixes a model breakage in PR #10.
2. Applies nits for variable / constant nomenclature.

**Related Issues:**

On merge, this PR:
1. Closes #12 
2. Closes #13