### PR TITLE
Misc: Persist polling result, poll latest block, versioning support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,9 @@ NETWORK=5 # Network to test. 1: Mainnet, 5: Goerli, 100: xDai
 # Optionally, specify the block number to process locally
 #   - useful for debugging or re-apply an old block to make sure the orders are created)
 #   - if not specified, it will run in WATCH mode, subscribing to all new blocks
+#   - Accepts either "latest" for the latest block, or the block number
 #BLOCK_NUMBER=9500767
+#BLOCK_NUMBER=latest
 BLOCK_NUMBER=
 
 # Slack

--- a/actions/checkForAndPlaceOrder.ts
+++ b/actions/checkForAndPlaceOrder.ts
@@ -241,7 +241,9 @@ async function _processConditionalOrder(
         chainId,
         conditionalOrder,
         contract,
-        multicall
+        multicall,
+        proof,
+        offchainInput
       );
     }
 
@@ -254,9 +256,10 @@ async function _processConditionalOrder(
 
     const orderToSubmit: Order = {
       ...order,
-      kind: kindToString(order.kind),
-      sellTokenBalance: balanceToString(order.sellTokenBalance),
-      buyTokenBalance: balanceToString(order.buyTokenBalance),
+      kind: kindToString(order.kind.toString()),
+      sellTokenBalance: balanceToString(order.sellTokenBalance.toString()),
+      buyTokenBalance: balanceToString(order.buyTokenBalance.toString()),
+      validTo: Number(order.validTo),
     };
 
     // calculate the orderUid
@@ -425,7 +428,9 @@ async function _pollLegacy(
   chainId: SupportedChainId,
   conditionalOrder: ConditionalOrder,
   contract: ComposableCoW,
-  multicall: Multicall3
+  multicall: Multicall3,
+  proof: string[],
+  offchainInput: string
 ): Promise<PollResult> {
   // as we going to use multicall, with `aggregate3Value`, there is no need to do any simulation as the
   // calls are guaranteed to pass, and will return the results, or the reversion within the ABI-encoded data.

--- a/actions/checkForAndPlaceOrder.ts
+++ b/actions/checkForAndPlaceOrder.ts
@@ -8,7 +8,7 @@ import {
 
 import axios from "axios";
 
-import { ethers, utils } from "ethers";
+import { ethers } from "ethers";
 import { BytesLike, Logger, hexlify } from "ethers/lib/utils";
 
 import {

--- a/actions/checkForAndPlaceOrder.ts
+++ b/actions/checkForAndPlaceOrder.ts
@@ -125,8 +125,11 @@ const _checkForAndPlaceOrder: ActionFn = async (
         ordersPendingDelete.push(conditionalOrder);
       }
 
-      // Save poll
-      conditionalOrder.pollResult = pollResult;
+      // Save poll result
+      conditionalOrder.pollResult = {
+        lastExecution: new Date(),
+        result: pollResult,
+      };
 
       // Log the result
       const unexpectedError =

--- a/actions/checkForAndPlaceOrder.ts
+++ b/actions/checkForAndPlaceOrder.ts
@@ -126,7 +126,9 @@ const _checkForAndPlaceOrder: ActionFn = async (
 
       // Save the latest poll result
       conditionalOrder.pollResult = {
-        lastExecution: new Date(),
+        lastExecutionTime: blockTimestamp,
+        blockNumber: blockNumber,
+
         result: pollResult,
       };
 

--- a/actions/checkForAndPlaceOrder.ts
+++ b/actions/checkForAndPlaceOrder.ts
@@ -118,14 +118,13 @@ const _checkForAndPlaceOrder: ActionFn = async (
         multicall,
         chainContext
       );
-      const isError = pollResult.result !== PollResultCode.SUCCESS;
 
       // Don't try again the same order, in case thats the poll result
       if (pollResult.result === PollResultCode.DONT_TRY_AGAIN) {
         ordersPendingDelete.push(conditionalOrder);
       }
 
-      // Save poll result
+      // Save the latest poll result
       conditionalOrder.pollResult = {
         lastExecution: new Date(),
         result: pollResult,
@@ -135,6 +134,8 @@ const _checkForAndPlaceOrder: ActionFn = async (
       const unexpectedError =
         pollResult?.result === PollResultCode.UNEXPECTED_ERROR;
 
+      // Print the polling result
+      const isError = pollResult.result !== PollResultCode.SUCCESS;
       const resultDescription =
         pollResult.result +
         (isError && pollResult.reason ? `. Reason: ${pollResult.reason}` : "");
@@ -177,6 +178,13 @@ const _checkForAndPlaceOrder: ActionFn = async (
 
   // Update the registry
   hasErrors ||= await !writeRegistry();
+
+  // console.log(
+  //   `[run_local] New CONDITIONAL_ORDER_REGISTRY value: `,
+  //   registry.stringifyOrders()
+  // );
+
+  Array.from(registry.ownerOrders.values()).flatMap((s) => s);
 
   // Throw execution error if there was at least one error
   if (hasErrors) {

--- a/actions/checkForSettlement.ts
+++ b/actions/checkForSettlement.ts
@@ -1,6 +1,5 @@
 import {
   ActionFn,
-  BlockEvent,
   Context,
   Event,
   Log,

--- a/actions/model.ts
+++ b/actions/model.ts
@@ -73,7 +73,8 @@ export type ConditionalOrder = {
    * The result of the last poll
    */
   pollResult?: {
-    lastExecution: Date;
+    lastExecutionTime: number;
+    blockNumber: number;
     result: PollResult;
   };
 };

--- a/actions/model.ts
+++ b/actions/model.ts
@@ -158,8 +158,12 @@ export class Registry {
   private async writeOrders(): Promise<void> {
     await this.storage.putStr(
       getOrdersStorageKey(this.network),
-      JSON.stringify(this.ownerOrders, replacer)
+      this.stringifyOrders()
     );
+  }
+
+  public stringifyOrders(): string {
+    return JSON.stringify(this.ownerOrders, replacer);
   }
 
   private async writeConditionalOrderRegistryVersion(): Promise<void> {

--- a/actions/model.ts
+++ b/actions/model.ts
@@ -6,7 +6,7 @@ import { BytesLike, ethers, providers } from "ethers";
 
 import { apiUrl, getProvider } from "./utils";
 import type { IConditionalOrder } from "./types/ComposableCoW";
-import { ConditionalOrderParams, SupportedChainId } from "@cowprotocol/cow-sdk";
+import { PollResult, SupportedChainId } from "@cowprotocol/cow-sdk";
 
 // Standardise the storage key
 const LAST_NOTIFIED_ERROR_STORAGE_KEY = "LAST_NOTIFIED_ERROR";
@@ -41,17 +41,35 @@ export enum OrderStatus {
 }
 
 export type ConditionalOrder = {
-  tx: string; // the transaction hash that created the conditional order (useful for debugging purposes)
+  /**
+   * The transaction hash that created the conditional order (useful for debugging purposes)
+   */
+  tx: string;
 
-  // the parameters of the conditional order
+  /**
+   * The parameters of the conditional order
+   */
   params: IConditionalOrder.ConditionalOrderParamsStruct; // TODO: We should not use the raw `ConditionalOrderParamsStruct` instead we should do some plain object `ConditionalOrderParams` with the handler,salt,staticInput as properties. See https://github.com/cowprotocol/tenderly-watch-tower/issues/18
-  // the merkle proof if the conditional order is belonging to a merkle root
-  // otherwise, if the conditional order is a single order, this is null
+
+  /**
+   * The merkle proof if the conditional order is belonging to a merkle root
+   * otherwise, if the conditional order is a single order, this is null
+   */
   proof: Proof | null;
-  // a map of discrete order hashes to their status
+  /**
+   *  Map of discrete order hashes to their status
+   */
   orders: Map<OrderUid, OrderStatus>;
-  // the address to poll for orders (may, or **may not** be `ComposableCoW`)
+
+  /**
+   * the address to poll for orders (may, or **may not** be `ComposableCoW`)
+   */
   composableCow: string;
+
+  /**
+   * The result of the last poll
+   */
+  pollResult?: PollResult;
 };
 
 /**
@@ -59,6 +77,7 @@ export type ConditionalOrder = {
  * Contains a map of owners to conditional orders and the last time we sent an error.
  */
 export class Registry {
+  version = 1;
   ownerOrders: Map<Owner, Set<ConditionalOrder>>;
   storage: Storage;
   network: string;

--- a/actions/model.ts
+++ b/actions/model.ts
@@ -148,32 +148,34 @@ export class Registry {
    * Write the registry to storage.
    */
   public async write(): Promise<void> {
-    const writeOrders = this.storage.putStr(
+    return Promise.all([
+      this.writeOrders(),
+      this.writeConditionalOrderRegistryVersion(),
+      this.writeLastNotifiedError(),
+    ]).then(() => {});
+  }
+
+  private async writeOrders(): Promise<void> {
+    await this.storage.putStr(
       getOrdersStorageKey(this.network),
       JSON.stringify(this.ownerOrders, replacer)
     );
+  }
 
-    const writeConditionalOrderRegistryVersion =
-      this.lastNotifiedError !== null
-        ? this.storage.putStr(
-            CONDITIONAL_ORDER_REGISTRY_VERSION_KEY,
-            this.version.toString()
-          )
-        : Promise.resolve();
+  private async writeConditionalOrderRegistryVersion(): Promise<void> {
+    await this.storage.putStr(
+      CONDITIONAL_ORDER_REGISTRY_VERSION_KEY,
+      this.version.toString()
+    );
+  }
 
-    const writeLastNotifiedError =
-      this.lastNotifiedError !== null
-        ? this.storage.putStr(
-            LAST_NOTIFIED_ERROR_STORAGE_KEY,
-            this.lastNotifiedError.toISOString()
-          )
-        : Promise.resolve();
-
-    return Promise.all([
-      writeOrders,
-      writeConditionalOrderRegistryVersion,
-      writeLastNotifiedError,
-    ]).then(() => {});
+  private async writeLastNotifiedError(): Promise<void> {
+    if (this.lastNotifiedError !== null) {
+      await this.storage.putStr(
+        LAST_NOTIFIED_ERROR_STORAGE_KEY,
+        this.lastNotifiedError.toISOString()
+      );
+    }
   }
 }
 

--- a/actions/model.ts
+++ b/actions/model.ts
@@ -149,11 +149,11 @@ export class Registry {
    * Write the registry to storage.
    */
   public async write(): Promise<void> {
-    return Promise.all([
+    await Promise.all([
       this.writeOrders(),
       this.writeConditionalOrderRegistryVersion(),
       this.writeLastNotifiedError(),
-    ]).then(() => {});
+    ]);
   }
 
   private async writeOrders(): Promise<void> {

--- a/actions/model.ts
+++ b/actions/model.ts
@@ -72,7 +72,10 @@ export type ConditionalOrder = {
   /**
    * The result of the last poll
    */
-  pollResult?: PollResult;
+  pollResult?: {
+    lastExecution: Date;
+    result: PollResult;
+  };
 };
 
 /**

--- a/actions/test/run_local.ts
+++ b/actions/test/run_local.ts
@@ -26,10 +26,19 @@ const main = async () => {
   const provider = await getProvider(testRuntime.context, chainId);
 
   // Run one of the 2 Execution modes (single block, or watch mode)
-  if (process.env.BLOCK_NUMBER) {
+  const blockNumberEnv = process.env.BLOCK_NUMBER;
+  if (blockNumberEnv) {
     // Execute once, for a specific block
-    const blockNumber = Number(process.env.BLOCK_NUMBER);
-    console.log(`[run_local] Processing specific block ${blockNumber}...`);
+    const isLatest = blockNumberEnv === "latest";
+    const blockNumber = isLatest
+      ? await provider.getBlockNumber()
+      : Number(blockNumberEnv);
+
+    console.log(
+      `[run_local] Processing ONCE for a specific block: ${
+        isLatest ? `latest (${blockNumber})` : blockNumber
+      }...`
+    );
     await processBlock(provider, blockNumber, chainId, testRuntime).catch(
       () => {
         exit(100);

--- a/actions/utils/poll.ts
+++ b/actions/utils/poll.ts
@@ -1,13 +1,13 @@
 import {
   ConditionalOrderFactory,
   ConditionalOrderParams,
-  DEFAULT_CONDITIONAL_ORDER_REGSTRY,
+  DEFAULT_CONDITIONAL_ORDER_REGISTRY,
   PollParams,
   PollResult,
 } from "@cowprotocol/cow-sdk";
 
 const ordersFactory = new ConditionalOrderFactory(
-  DEFAULT_CONDITIONAL_ORDER_REGSTRY
+  DEFAULT_CONDITIONAL_ORDER_REGISTRY
 );
 
 export async function pollConditionalOrder(

--- a/actions/utils/poll.ts
+++ b/actions/utils/poll.ts
@@ -19,6 +19,6 @@ export async function pollConditionalOrder(
   if (!order) {
     return undefined;
   }
-
+  console.log(`[polling] Polling for ${order.toString()}....`);
   return order.poll(pollParams);
 }


### PR DESCRIPTION
# Misc changes
This PR makes some small improvements, in principle not very related, but to keep things simpler, i prefer to do in a single PR

## Log the Conditional Order using the SDK
The conditional orders have a `toString` implementation that would show in plain English the order details. This is super handy to understand any issues with the Polling Logic that come after:
<img width="1499" alt="image" src="https://github.com/cowprotocol/tenderly-watch-tower/assets/2352112/3eda0282-41c3-4e1e-8264-7d7330a6fe16">

## Persist the Poll Result
> ⚠️ This change modifies the model, however the change is backwards compatible

I added the `pollResult` to the conditional order, with the latest poll result.

## Add a basic versioning to the conditional order model
Although this PR is backward compatible with the model, a future PR might not be. 

<img width="1095" alt="image" src="https://github.com/cowprotocol/tenderly-watch-tower/assets/2352112/7a5700b2-bc18-4225-8cfd-f40ec9598344">


This is why I want to introduce in this PR some versioning on the conditional order model.

The key is the revived function, it will receive the current version that needs to be parsed. It's expected that the function will parse the registry and convert it to the latest version, effectively applying a model migration. 

In this PR, because there's no breaking change, we can just ignore the version number that is passed as a parameter. 

## Allow to index once for the latest block
One feature of this project is that you can run it once for a specific block .
Another one, is we can place the storage from tenderly in the `STORAGE` env (to reproduce Tenderly state)

If you experience an issue in Tenderly indexing and you want to run locally, its convenient to copy the storage, and then run it on the latest block.

This PR allows to provide `BLOCK_NUMBER=latest` in the env to do this.


# Not included
This PR is preparation for the next one, that will handle the `pollResult` errors, to ignore the indexing of some blocks