### PR TITLE
Add loggly

### DIFF
--- a/actions/checkForAndPlaceOrder.ts
+++ b/actions/checkForAndPlaceOrder.ts
@@ -9,7 +9,7 @@ import {
 import axios from "axios";
 
 import { ethers } from "ethers";
-import { BytesLike, Logger, hexlify } from "ethers/lib/utils";
+import { BytesLike, Logger } from "ethers/lib/utils";
 
 import {
   ComposableCoW,

--- a/actions/package.json
+++ b/actions/package.json
@@ -29,7 +29,8 @@
     "graphql-request": "^6.1.0",
     "node-fetch": "2",
     "node-slack": "^0.0.7",
-    "typescript": "^5.0.4"
+    "typescript": "^5.0.4",
+    "winston-loggly-bulk": "^3.2.1"
   },
   "private": true,
   "jest": {

--- a/actions/test/run_local.ts
+++ b/actions/test/run_local.ts
@@ -163,6 +163,7 @@ async function _getRunTime(chainId: SupportedChainId): Promise<TestRuntime> {
     "SLACK_WEBHOOK_URL",
     "NOTIFICATIONS_ENABLED",
     "SENTRY_DSN",
+    "LOGGLY_TOKEN",
   ];
   for (const name of envNames) {
     const envValue = process.env[name];

--- a/actions/utils/context.ts
+++ b/actions/utils/context.ts
@@ -218,7 +218,7 @@ async function _initLogging(
 ) {
   const logglyToken = await context.secrets.get("LOGGLY_TOKEN").catch(() => "");
   if (logglyToken) {
-    initLogging(logglyToken, [transactionName, `chain:${chainId}`]);
+    initLogging(logglyToken, [transactionName, `chain_${chainId}`]);
   } else {
     console.warn("LOGGLY_TOKEN is not set, logging to console only");
   }

--- a/actions/utils/context.ts
+++ b/actions/utils/context.ts
@@ -21,7 +21,9 @@ export async function initContext(
   chainId: SupportedChainId,
   context: Context
 ): Promise<ExecutionContext> {
-  initLogging();
+  // Init Logging
+  await _initLogging(transactionName, chainId, context);
+
   // Init registry
   const registry = await Registry.load(context, chainId.toString());
 
@@ -204,4 +206,20 @@ function handlePromiseErrors<T>(
       console.error(errorMessage, error);
       return false;
     });
+}
+
+/**
+ * Init Logging with Loggly
+ */
+async function _initLogging(
+  transactionName: string,
+  chainId: SupportedChainId,
+  context: Context
+) {
+  const logglyToken = await context.secrets.get("LOGGLY_TOKEN").catch(() => "");
+  if (logglyToken) {
+    console.warn("LOGGLY_TOKEN is not set, logging to console only");
+  } else {
+    initLogging(logglyToken, [transactionName, `chain:${chainId}`]);
+  }
 }

--- a/actions/utils/context.ts
+++ b/actions/utils/context.ts
@@ -218,8 +218,8 @@ async function _initLogging(
 ) {
   const logglyToken = await context.secrets.get("LOGGLY_TOKEN").catch(() => "");
   if (logglyToken) {
-    console.warn("LOGGLY_TOKEN is not set, logging to console only");
-  } else {
     initLogging(logglyToken, [transactionName, `chain:${chainId}`]);
+  } else {
+    console.warn("LOGGLY_TOKEN is not set, logging to console only");
   }
 }

--- a/actions/utils/context.ts
+++ b/actions/utils/context.ts
@@ -10,6 +10,7 @@ import { CaptureConsole as CaptureConsoleIntegration } from "@sentry/integration
 
 import { ExecutionContext, Registry } from "../model";
 import { SupportedChainId } from "@cowprotocol/cow-sdk";
+import { initLogging } from "./logging";
 
 const NOTIFICATION_WAIT_PERIOD = 1000 * 60 * 60 * 2; // 2h - Don't send more than one notification every 2h
 
@@ -20,6 +21,7 @@ export async function initContext(
   chainId: SupportedChainId,
   context: Context
 ): Promise<ExecutionContext> {
+  initLogging();
   // Init registry
   const registry = await Registry.load(context, chainId.toString());
 

--- a/actions/utils/logging.ts
+++ b/actions/utils/logging.ts
@@ -1,0 +1,45 @@
+import assert = require("assert");
+import winston = require("winston");
+const { Loggly } = require("winston-loggly-bulk");
+
+export function initLogging() {
+  const LOGGLY_TOKEN = process.env.LOGGLY_TOKEN;
+  assert(LOGGLY_TOKEN, "LOGGLY_TOKEN is required");
+  winston.add(
+    new Loggly({
+      token: LOGGLY_TOKEN,
+      subdomain: "cowprotocol",
+      tags: ["Winston-NodeJS"],
+      json: true,
+    })
+  );
+
+  const consoleOriginal = {
+    log: console.log,
+    warn: console.warn,
+    error: console.error,
+    debug: console.debug,
+    info: console.info,
+  };
+
+  type LogLevel = "warn" | "info" | "error" | "debug";
+  const logWithLoggly =
+    (level: LogLevel) =>
+    (...data: any[]) => {
+      if (data.length > 1) {
+        const [message, meta] = data;
+        winston.log({ level, message, ...meta });
+      } else if (data.length === 1) {
+        winston.log({ level, message: data[0] });
+      }
+      consoleOriginal[level](...data);
+    };
+
+  // Override the log function since some internal libraries might print something and breaks Tenderly
+
+  console.info = logWithLoggly("info");
+  console.warn = logWithLoggly("warn");
+  console.error = logWithLoggly("error");
+  console.debug = logWithLoggly("debug");
+  console.log = logWithLoggly("info");
+}

--- a/actions/utils/logging.ts
+++ b/actions/utils/logging.ts
@@ -2,26 +2,31 @@ import assert = require("assert");
 import winston = require("winston");
 const { Loggly } = require("winston-loggly-bulk");
 
-let initialized = false;
+let logger: undefined | any;
 
 export function initLogging(
   logglyToken: string,
   tags: string[],
   logOnlyIfError = false
 ) {
-  if (initialized) {
+  const newLogger = new Loggly({
+    token: logglyToken,
+    subdomain: "cowprotocol",
+    tags,
+    json: true,
+  });
+
+  if (logger !== undefined) {
+    // We had a previous logger, remove it and add the new one
+    winston.remove(logger);
+    winston.add(newLogger);
+    logger = newLogger;
     return;
   }
 
-  initialized = true;
-  winston.add(
-    new Loggly({
-      token: logglyToken,
-      subdomain: "cowprotocol",
-      tags,
-      json: true,
-    })
-  );
+  // We didn't have a previous logger, just add the new one
+  logger = newLogger;
+  winston.add(logger);
 
   const consoleOriginal = {
     log: console.log,

--- a/actions/utils/logging.ts
+++ b/actions/utils/logging.ts
@@ -2,15 +2,20 @@ import assert = require("assert");
 import winston = require("winston");
 const { Loggly } = require("winston-loggly-bulk");
 
-export function initLogging() {
-  const LOGGLY_TOKEN = process.env.LOGGLY_TOKEN;
-  assert(LOGGLY_TOKEN, "LOGGLY_TOKEN is required");
+let initialized = false;
+
+export function initLogging(logglyToken: string, tags: string[]) {
+  if (initialized) {
+    return;
+  }
+
+  initialized = true;
   winston.add(
     new Loggly({
-      token: LOGGLY_TOKEN,
+      token: logglyToken,
       subdomain: "cowprotocol",
-      tags: ["Winston-NodeJS"],
-      json: true,
+      tags,
+      json: false,
     })
   );
 
@@ -28,7 +33,7 @@ export function initLogging() {
     (...data: any[]) => {
       if (data.length > 1) {
         const [message, meta] = data;
-        winston.log({ level, message, ...meta });
+        winston.log({ level, message, meta });
       } else if (data.length === 1) {
         winston.log({ level, message: data[0] });
       }

--- a/actions/utils/logging.ts
+++ b/actions/utils/logging.ts
@@ -15,7 +15,7 @@ export function initLogging(logglyToken: string, tags: string[]) {
       token: logglyToken,
       subdomain: "cowprotocol",
       tags,
-      json: false,
+      json: true,
     })
   );
 


### PR DESCRIPTION
Test to log into a different tool: Loggly

They index the logs, which is nice, because they will identify for example the parameters from the order:
![image](https://github.com/cowprotocol/tenderly-watch-tower/assets/2352112/0fed4295-0a14-4339-b79b-7dc1f1b49ace)

this PR adds also some tags to facilitate the filtering. 
We can filter by the tenderly operation, for example `addContract`, but also by chain `chain_100`:
![image](https://github.com/cowprotocol/tenderly-watch-tower/assets/2352112/28235b68-138c-4b51-9620-9314d7571c8e)

We can filter by the values of specific  fields, and they show the different values they have for the field, for example, here we can actually see how many errors we get from the API and which type:
![image](https://github.com/cowprotocol/tenderly-watch-tower/assets/2352112/e8a1602b-0979-46c9-9042-58c69b2f353a)

We can easily filter by owner for example too:
![image](https://github.com/cowprotocol/tenderly-watch-tower/assets/2352112/302300ee-784e-4c86-a925-95d7ad4f4029)


## Log only if error
For now, I'm in the 30 days trial period, but when is over, we will need to pay for the usage

If we log over 1GB a day is super expensive. This is easy to supus given we are verbose and we index block for 3 chains. 

This PR includes a flag we can enable in the future to:
- Accumulate logs in a buffer
- Only print those logs if we get at a later point an error. This will serve as an "context for that error"

