### PR TITLE
feat: state rebuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ yarn build
 yarn ts-node ./actions/test/run_local.ts
 ```
 
+### Watch tower state
+
+As the Tenderly watch tower stores data in an abstracted manner, and there have been cases witnessed in production where the storage
+has reported odd errors, it is useful to be able to rebuild the state of what _should_ be in the watch tower for quality assurance /
+resilience purposes.
+
+To run the state rebuilder locally, use the previous command in [Local testing](#Local-testing) and set the environment variables:
+
+- `BLOCK_NUMBER`: The block number to start from (defaults to `0`)
+- `PAGE_SIZE`: The page size for `eth_getLogs` (defaults to `5000` to support Infura)
+- `CONTRACT_ADDRESS`: The address of the `ComposableCoW` contract.
+
+Other environment variables such as the RPC node URL and notifications MUST be set as well.
+
 ### Deployment
 
 If running your own watch tower, or deploying for production:

--- a/actions/checkForAndPlaceOrder.ts
+++ b/actions/checkForAndPlaceOrder.ts
@@ -208,15 +208,13 @@ const _checkForAndPlaceOrder: ActionFn = async (
     }
   }
 
-  // TODO: Decide if we want to delete owners with no orders
-  //    - One one hand, we don't want to keep growing our registry forever
-  //    - On the other hand, it might be handy to know this owner has been verified before
-  // // Delete owners with no orders
-  // for (const [owner, conditionalOrders] of Array.from(ownerOrders.entries())) {
-  //   if (conditionalOrders.size === 0) {
-  //     ownerOrders.delete(owner);
-  //   }
-  // }
+  // It may be handy in other versions of the watch tower implemented in other languages
+  // (ie. not for Tenderly) to not delete owners, so we can keep track of them.
+  for (const [owner, conditionalOrders] of Array.from(ownerOrders.entries())) {
+    if (conditionalOrders.size === 0) {
+      ownerOrders.delete(owner);
+    }
+  }
 
   // Update the registry
   hasErrors ||= await !writeRegistry();

--- a/actions/model.ts
+++ b/actions/model.ts
@@ -30,6 +30,11 @@ export interface ReplayPlan {
   [key: number]: Set<string>;
 }
 
+export interface ProcessBlockOverrides {
+  txList?: string[];
+  blockWatchBlockNumber?: number;
+}
+
 /**
  * A merkle proof is a set of parameters:
  * - `merkleRoot`: the merkle root of the conditional order

--- a/actions/model.ts
+++ b/actions/model.ts
@@ -26,6 +26,10 @@ export interface ExecutionContext {
   context: Context;
 }
 
+export interface ReplayPlan {
+  [key: number]: Set<string>;
+}
+
 /**
  * A merkle proof is a set of parameters:
  * - `merkleRoot`: the merkle root of the conditional order

--- a/actions/test/run_local.ts
+++ b/actions/test/run_local.ts
@@ -119,7 +119,7 @@ const main = async () => {
       }
     } while (toBlock !== 'latest' && (typeof toBlock !== 'string' && toBlock != currentBlockNumber));
 
-    // 5. Replay the blocks by iterating over the replayPlan
+    // 6. Replay the blocks by iterating over the replayPlan
     for (const [blockNumber, txHints] of Object.entries(replayPlan)) {
       console.log(`[run_rebuild] Processing block ${blockNumber}`);
       const overrides: ProcessBlockOverrides = {
@@ -133,7 +133,7 @@ const main = async () => {
       );
       console.log(`[run_rebuild] Block ${blockNumber} has been processed.`);
     }
-    // 6. Print the storage
+    // 7. Print the storage
     testRuntime.context.storage.getJson(getOrdersStorageKey(chainId.toString())).then((storage) => {
       console.log(`[run_rebuild] Storage: ${JSON.stringify(storage)}`);
     })


### PR DESCRIPTION
# Description
Given the issues that have been identified in production around the Tenderly Watch Tower, it has become a necessity to inspect / audit the watch tower's state for quality assurance / resilience testing purposes.

# Changes
The `run_local` was updated with the following functionality:

- [x] Add environment variable configuration to trigger rebuild code path.
- [x] Add query filter for `ComposableCoW` contract with paging support for Infura (if required).

## How to test
Follow the instructions in the `README.md` supplement for how to rebuild the state.

## Related Issues

Closes #28 