### PR TITLE
Optimise stored state

### DIFF
--- a/actions/checkForAndPlaceOrder.ts
+++ b/actions/checkForAndPlaceOrder.ts
@@ -208,15 +208,13 @@ const _checkForAndPlaceOrder: ActionFn = async (
     }
   }
 
-  // TODO: Decide if we want to delete owners with no orders
-  //    - One one hand, we don't want to keep growing our registry forever
-  //    - On the other hand, it might be handy to know this owner has been verified before
-  // // Delete owners with no orders
-  // for (const [owner, conditionalOrders] of Array.from(ownerOrders.entries())) {
-  //   if (conditionalOrders.size === 0) {
-  //     ownerOrders.delete(owner);
-  //   }
-  // }
+  // It may be handy in other versions of the watch tower implemented in other languages
+  // (ie. not for Tenderly) to not delete owners, so we can keep track of them.
+  for (const [owner, conditionalOrders] of Array.from(ownerOrders.entries())) {
+    if (conditionalOrders.size === 0) {
+      ownerOrders.delete(owner);
+    }
+  }
 
   // Update the registry
   hasErrors ||= await !writeRegistry();


### PR DESCRIPTION
# Description
The watch tower has in production had timeout issues with storage. Therefore, storage should be assumed to be super expensive to call / retrieve, so we should minimise the amount of state that we are storing.

# Changes
If an owner no longer has any conditional orders being monitored - remove them from the registry.

- [x] Remove owners with no orders being monitored.

## How to test
Using PR #29 run a local store rebuild and observe that the end state returned does not contain any owners with no orders.

## Related Issues

Closes #30 