### PR TITLE
Allow to index single tx and improve logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ NETWORK=5 # Network to test. 1: Mainnet, 5: Goerli, 100: xDai
 #BLOCK_NUMBER=latest
 BLOCK_NUMBER=
 
+
+#TX=0xf8796f6f012fb6a437da84bb0a4c06f3f41af16aaca68384134145a93f17ffe0
+TX=
+
 # Slack
 SLACK_WEBHOOK_URL=
 NOTIFICATIONS_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -93,9 +93,8 @@ yarn build:actions
 #   - As a result, new Composable Cow orders will be discovered and posted to the OrderBook API
 yarn start:actions
 
-# You can re-process an old block by:
-#   - Add an env BLOCK_NUMBER
-#   - Add an env TX
-#   - Run actions locally
+# You can re-process an old block by defining the following environment variables:
+#   - Add an env TX: Process only one transaction (takes precedence over BLOCK_NUMBER)
+#   - Add an env BLOCK_NUMBER: Process only one block
 yarn start:actions
 ```

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ yarn start:actions
 
 # You can re-process an old block by:
 #   - Add an env BLOCK_NUMBER
+#   - Add an env TX
 #   - Run actions locally
 yarn start:actions
 ```

--- a/actions/addContract.ts
+++ b/actions/addContract.ts
@@ -61,17 +61,23 @@ const _addContract: ActionFn = async (context: Context, event: Event) => {
     );
     if (added) {
       numContractsAdded++;
+    } else {
+      console.error(
+        `[addContract] Failed to register Smart Order from tx ${tx} on block ${transactionEvent.blockNumber}. Error: ${error}`
+      );
     }
     hasErrors ||= error;
   }
 
-  console.log(`[addContract] Added ${numContractsAdded} contracts`);
-  hasErrors ||= !(await writeRegistry());
-  // Throw execution error if there was at least one error
-  if (hasErrors) {
-    throw Error(
-      "[addContract] Error adding conditional order. Event: " + event
-    );
+  if (numContractsAdded > 0) {
+    console.log(`[addContract] Added ${numContractsAdded} contracts`);
+    hasErrors ||= !(await writeRegistry());
+    // Throw execution error if there was at least one error
+    if (hasErrors) {
+      throw Error(
+        "[addContract] Error adding conditional order. Event: " + event
+      );
+    }
   }
 };
 
@@ -138,7 +144,7 @@ export async function _registerNewOrder(
     }
   } catch (error) {
     console.error(
-      "[addContract] Error handling ConditionalOrderCreated/MerkleRootSet event" +
+      `[addContract] Error handling ConditionalOrderCreated/MerkleRootSet event for tx: ${tx}` +
         error
     );
     return { error: true, added };

--- a/actions/checkForAndPlaceOrder.ts
+++ b/actions/checkForAndPlaceOrder.ts
@@ -182,7 +182,14 @@ const _checkForAndPlaceOrder: ActionFn = async (
         pollResult.result +
         (isError && pollResult.reason ? `. Reason: ${pollResult.reason}` : "");
 
-      console[isError ? "error" : "log"](
+      const logLevel =
+        pollResult.result === PollResultCode.SUCCESS
+          ? "log"
+          : pollResult.result === PollResultCode.UNEXPECTED_ERROR
+          ? "error"
+          : "warn";
+
+      console[logLevel](
         `${logPrefix} Check conditional order result: ${getEmojiByPollResult(
           pollResult?.result
         )} ${resultDescription}`

--- a/actions/test/run_local.ts
+++ b/actions/test/run_local.ts
@@ -215,14 +215,11 @@ async function processBlock(
     }
   }
 
-  const pollingBlock = overrides?.blockWatchBlockNumber
-    ? await provider.getBlock(blockNumber)
-    : block;
-
   hasErrors ||= !(await _pollAndPost({
-    block: pollingBlock,
+    block,
     chainId,
     testRuntime,
+    blockWatchBlockNumber: overrides?.blockWatchBlockNumber,
   }));
 
   if (hasErrors) {
@@ -325,16 +322,18 @@ async function _pollAndPost({
   block,
   chainId,
   testRuntime,
+  blockWatchBlockNumber,
 }: {
   block: ethers.providers.Block;
   chainId: number;
   testRuntime: TestRuntime;
+  blockWatchBlockNumber?: number;
 }) {
   const blockNumber = block.number;
 
   // Block watcher for creating new orders
   const testBlockEvent = new TestBlockEvent();
-  testBlockEvent.blockNumber = blockNumber;
+  testBlockEvent.blockNumber = blockWatchBlockNumber ?? blockNumber;
   testBlockEvent.blockDifficulty = block.difficulty?.toString();
   testBlockEvent.blockHash = block.hash;
   testBlockEvent.network = chainId.toString();

--- a/actions/test/run_local.ts
+++ b/actions/test/run_local.ts
@@ -8,7 +8,11 @@ import { addContract } from "../addContract";
 import { ethers } from "ethers";
 import assert = require("assert");
 import { toChainId, getProvider } from "../utils";
-import { ProcessBlockOverrides, ReplayPlan, getOrdersStorageKey } from "../model";
+import {
+  ProcessBlockOverrides,
+  ReplayPlan,
+  getOrdersStorageKey,
+} from "../model";
 import { exit } from "process";
 import { SupportedChainId } from "@cowprotocol/cow-sdk";
 import { ComposableCoW__factory } from "../types/factories/ComposableCoW__factory";
@@ -30,9 +34,27 @@ const main = async () => {
   const provider = await getProvider(testRuntime.context, chainId);
 
   // Run one of the 3 Execution modes (single block, watch mode, or rebuild mode)
-  const blockNumberEnv = process.env.BLOCK_NUMBER;
   const contractAddressEnv = process.env.CONTRACT_ADDRESS;
-  if (blockNumberEnv && !contractAddressEnv) {
+
+  // Run one of the 3 Execution modes:
+  //  - Single tx: Process just one tx
+  //  - Single block: Process just one block
+  //  - Watch mode: Watch for new blocks, and process them
+  //  - Rebuild state mode
+  const txEnv = process.env.TX;
+  const blockNumberEnv = process.env.BLOCK_NUMBER;
+  if (txEnv) {
+    // Execute once, for a specific tx
+    console.log(
+      `[run_local] Processing ONCE for a specific transaction: ${txEnv}...`
+    );
+
+    await processTx(provider, txEnv, chainId, testRuntime).catch(() => {
+      exit(101);
+    });
+
+    console.log(`[run_local] Transaction ${txEnv} has been processed.`);
+  } else if (blockNumberEnv && !contractAddressEnv) {
     // Execute once, for a specific block
     const isLatest = blockNumberEnv === "latest";
     const blockNumber = isLatest
@@ -50,7 +72,7 @@ const main = async () => {
       }
     );
     console.log(`[run_local] Block ${blockNumber} has been processed.`);
-  } else if (!blockNumberEnv && !contractAddressEnv){
+  } else if (!blockNumberEnv && !contractAddressEnv) {
     // Watch for new blocks
     console.log(`[run_local] Subscribe to new blocks for network ${network}`);
     provider.on("block", async (blockNumber: number) => {
@@ -63,17 +85,28 @@ const main = async () => {
   } else if (contractAddressEnv) {
     // If no blockNumberEnv is provided, then we rebuild the state from the default deployment block
     if (!blockNumberEnv) {
-      console.log(`[run_rebuild] No block number provided, using default deployment block`);
+      console.log(
+        `[run_rebuild] No block number provided, using default deployment block`
+      );
     } else {
       assert(!isNaN(Number(blockNumberEnv)), "blockNumber must be a number");
     }
-    let fromBlock = blockNumberEnv ? Number(blockNumberEnv) : DEFAULT_DEPLOYMENT_BLOCK;
+    let fromBlock = blockNumberEnv
+      ? Number(blockNumberEnv)
+      : DEFAULT_DEPLOYMENT_BLOCK;
 
     // Rebuild the state
-    console.log(`[run_rebuild] Rebuild the state of the conditional orders from the historical events.`);
+    console.log(
+      `[run_rebuild] Rebuild the state of the conditional orders from the historical events.`
+    );
     const contractAddress = process.env.CONTRACT_ADDRESS;
-    assert(contractAddress && ethers.utils.isAddress(contractAddress), "contract address is required");
-    const pageSize = process.env.PAGE_SIZE ? parseInt(process.env.PAGE_SIZE) : DEFAULT_PAGE_SIZE;
+    assert(
+      contractAddress && ethers.utils.isAddress(contractAddress),
+      "contract address is required"
+    );
+    const pageSize = process.env.PAGE_SIZE
+      ? parseInt(process.env.PAGE_SIZE)
+      : DEFAULT_PAGE_SIZE;
 
     // 1. Record the current block number - useful with paging
     let currentBlockNumber = await provider.getBlockNumber();
@@ -81,24 +114,28 @@ const main = async () => {
 
     // 2. Connect to the contract instance
     const contract = ComposableCoW__factory.connect(contractAddress, provider);
-    
+
     // 3. Define the filter.
     const filter = contract.filters.ConditionalOrderCreated();
 
     // 4. Get the historical events
-    const replayPlan: ReplayPlan = {}
-    let toBlock: 'latest' | number = 0;
+    const replayPlan: ReplayPlan = {};
+    let toBlock: "latest" | number = 0;
     do {
-      toBlock = !pageSize ? 'latest' : fromBlock + (pageSize - 1);
-      if (!isNaN(toBlock) && toBlock > currentBlockNumber) {
-          // refresh the current block number
-          currentBlockNumber = await provider.getBlockNumber();
-          toBlock = (toBlock > currentBlockNumber) ? currentBlockNumber : toBlock;
+      toBlock = !pageSize ? "latest" : fromBlock + (pageSize - 1);
+      if (typeof toBlock === "number" && toBlock > currentBlockNumber) {
+        // refresh the current block number
+        currentBlockNumber = await provider.getBlockNumber();
+        toBlock = toBlock > currentBlockNumber ? currentBlockNumber : toBlock;
 
-          console.log(`[run_rebuild] Reaching tip of chain, current block number: ${currentBlockNumber}`);
+        console.log(
+          `[run_rebuild] Reaching tip of chain, current block number: ${currentBlockNumber}`
+        );
       }
 
-      console.log(`[run_rebuild] Processing events from block ${fromBlock} to block ${toBlock}`);
+      console.log(
+        `[run_rebuild] Processing events from block ${fromBlock} to block ${toBlock}`
+      );
 
       const events = await contract.queryFilter(filter, fromBlock, toBlock);
 
@@ -114,29 +151,37 @@ const main = async () => {
       }
 
       // only possible string value for toBlock is 'latest'
-      if (typeof toBlock === 'number') {
-          fromBlock = toBlock + 1;
+      if (typeof toBlock === "number") {
+        fromBlock = toBlock + 1;
       }
-    } while (toBlock !== 'latest' && toBlock !== currentBlockNumber);
+    } while (toBlock !== "latest" && toBlock !== currentBlockNumber);
 
     // 6. Replay the blocks by iterating over the replayPlan
     for (const [blockNumber, txHints] of Object.entries(replayPlan)) {
       console.log(`[run_rebuild] Processing block ${blockNumber}`);
       const overrides: ProcessBlockOverrides = {
         blockWatchBlockNumber: currentBlockNumber,
-        txList: Array.from(txHints)
+        txList: Array.from(txHints),
+      };
+      try {
+        await processBlock(
+          provider,
+          Number(blockNumber),
+          chainId,
+          testRuntime,
+          overrides
+        );
+      } catch {
+        exit(100);
       }
-     try {
-       await processBlock(provider, Number(blockNumber), chainId, testRuntime, overrides)
-     } catch {
-         exit(100);
-     }
       console.log(`[run_rebuild] Block ${blockNumber} has been processed.`);
     }
     // 7. Print the storage
-    testRuntime.context.storage.getJson(getOrdersStorageKey(chainId.toString())).then((storage) => {
-      console.log(`[run_rebuild] Storage: ${JSON.stringify(storage)}`);
-    })
+    testRuntime.context.storage
+      .getJson(getOrdersStorageKey(chainId.toString()))
+      .then((storage) => {
+        console.log(`[run_rebuild] Storage: ${JSON.stringify(storage)}`);
+      });
   }
 };
 
@@ -155,63 +200,133 @@ async function processBlock(
   );
   let hasErrors = false;
   for (const transaction of blockWithTransactions.transactions) {
-    if (overrides?.txList && !overrides.txList.includes(transaction.hash)) {
-      continue;
-    }
-    const receipt = await provider.getTransactionReceipt(transaction.hash);
-    if (receipt) {
-      const {
-        hash,
-        from,
-        value,
-        nonce,
-        gasLimit,
-        maxPriorityFeePerGas,
-        maxFeePerGas,
-      } = transaction;
+    const shouldProcessTx =
+      overrides?.txList?.includes(transaction.hash) ?? true;
 
-      const testTransactionEvent: TestTransactionEvent = {
-        blockHash: block.hash,
-        blockNumber: block.number,
-        from,
-        hash,
-        network: chainId.toString(),
-        logs: receipt.logs,
-        input: "",
-        value: value.toString(),
-        nonce: nonce.toString(),
-        gas: gasLimit.toString(),
-        gasUsed: receipt.gasUsed.toString(),
-        cumulativeGasUsed: receipt.cumulativeGasUsed.toString(),
-        gasPrice: receipt.effectiveGasPrice.toString(),
-        gasTipCap: maxPriorityFeePerGas ? maxPriorityFeePerGas.toString() : "",
-        gasFeeCap: maxFeePerGas ? maxFeePerGas.toString() : "",
-        transactionHash: transaction.hash,
-      };
-
-      // run action
-      const result = await testRuntime
-        .execute(addContract, testTransactionEvent)
-        .then(() => true)
-        .catch((e) => {
-          hasErrors = true;
-          console.error(
-            `[run_local] Error running "addContract" action for TX:`,
-            e
-          );
-          return false;
-        });
-      console.log(
-        `[run_local] Result of "addContract" action for TX ${hash}: ${_formatResult(
-          result
-        )}`
+    if (shouldProcessTx) {
+      hasErrors ||= await !_processTx(
+        provider,
+        block,
+        chainId,
+        testRuntime,
+        transaction
       );
     }
   }
 
+  const pollingBlock = overrides?.blockWatchBlockNumber
+    ? await provider.getBlock(blockNumber)
+    : block;
+
+  hasErrors ||= !(await _pollAndPost({
+    block: pollingBlock,
+    chainId,
+    testRuntime,
+  }));
+
+  if (hasErrors) {
+    throw new Error("[run_local] Errors found in processing block");
+  }
+}
+
+async function processTx(
+  provider: ethers.providers.Provider,
+  tx: string,
+  chainId: number,
+  testRuntime: TestRuntime
+) {
+  // Execute once, for a specific tx
+  console.log(
+    `[run_local] Processing ONCE for a specific transaction: ${tx}...`
+  );
+  const transaction = await provider.getTransaction(tx);
+  if (!transaction.blockNumber) {
+    throw new Error(`The transaction ${tx} is not mined yet (no blockNumber)`);
+  }
+  const block = await provider.getBlock(transaction.blockNumber);
+  if (!transaction) {
+    throw new Error(`[run_local] Transaction ${tx} not found`);
+  }
+
+  await _processTx(provider, block, chainId, testRuntime, transaction);
+  await _pollAndPost({ block, chainId, testRuntime });
+}
+
+async function _processTx(
+  provider: ethers.providers.Provider,
+  block: ethers.providers.Block,
+  chainId: number,
+  testRuntime: TestRuntime,
+  transaction: ethers.providers.TransactionResponse
+): Promise<boolean> {
+  const receipt = await provider.getTransactionReceipt(transaction.hash);
+  if (receipt) {
+    const {
+      hash,
+      from,
+      value,
+      nonce,
+      gasLimit,
+      maxPriorityFeePerGas,
+      maxFeePerGas,
+    } = transaction;
+
+    const testTransactionEvent: TestTransactionEvent = {
+      blockHash: block.hash,
+      blockNumber: block.number,
+      from,
+      hash,
+      network: chainId.toString(),
+      logs: receipt.logs,
+      input: "",
+      value: value.toString(),
+      nonce: nonce.toString(),
+      gas: gasLimit.toString(),
+      gasUsed: receipt.gasUsed.toString(),
+      cumulativeGasUsed: receipt.cumulativeGasUsed.toString(),
+      gasPrice: receipt.effectiveGasPrice.toString(),
+      gasTipCap: maxPriorityFeePerGas ? maxPriorityFeePerGas.toString() : "",
+      gasFeeCap: maxFeePerGas ? maxFeePerGas.toString() : "",
+      transactionHash: transaction.hash,
+    };
+
+    // run action
+    const result = await testRuntime
+      .execute(addContract, testTransactionEvent)
+      .then(() => true)
+      .catch((e) => {
+        console.error(
+          `[run_local] Error running "addContract" action for TX:`,
+          e
+        );
+        return false;
+      });
+    console.log(
+      `[run_local] Result of "addContract" action for TX ${hash}: ${_formatResult(
+        result
+      )}`
+    );
+
+    return result;
+  }
+
+  return true;
+}
+
+async function _pollAndPost({
+  block,
+  chainId,
+  testRuntime,
+}: {
+  block: ethers.providers.Block;
+  chainId: number;
+  testRuntime: TestRuntime;
+}) {
+  const blockNumber = block.number;
+
   // Block watcher for creating new orders
   const testBlockEvent = new TestBlockEvent();
-  testBlockEvent.blockNumber = overrides?.blockWatchBlockNumber ?? blockNumber;
+  testBlockEvent.blockNumber = blockNumber;
   testBlockEvent.blockDifficulty = block.difficulty?.toString();
   testBlockEvent.blockHash = block.hash;
   testBlockEvent.network = chainId.toString();
@@ -221,8 +336,7 @@ async function processBlock(
   const result = await testRuntime
     .execute(checkForAndPlaceOrder, testBlockEvent)
     .then(() => true)
-    .catch((e) => {
-      hasErrors = true;
+    .catch(() => {
       console.log(`[run_local] Error running "checkForAndPlaceOrder" action`);
       return false;
     });
@@ -232,9 +346,7 @@ async function processBlock(
     )}`
   );
 
-  if (hasErrors) {
-    throw new Error("[run_local] Errors found in processing block");
-  }
+  return result;
 }
 
 async function _getRunTime(chainId: SupportedChainId): Promise<TestRuntime> {

--- a/actions/test/run_local.ts
+++ b/actions/test/run_local.ts
@@ -226,7 +226,7 @@ async function processBlock(
   }));
 
   if (hasErrors) {
-    throw new Error("[run_local] Errors found in processing block");
+    throw new Error(`[run_local] Errors found in processing block: ${block}`);
   }
 }
 
@@ -256,7 +256,7 @@ async function processTx(
   hasErrors ||= !(await _pollAndPost({ block, chainId, testRuntime }));
 
   if (hasErrors) {
-    throw new Error("[run_local] Errors found in processing TX");
+    throw new Error(`[run_local] Errors found in processing TX: ${tx}`);
   }
 }
 
@@ -304,7 +304,7 @@ async function _processTx(
       .then(() => true)
       .catch((e) => {
         console.error(
-          `[run_local] Error running "addContract" action for TX:`,
+          `[run_local] Error running "addContract" action for TX: ${hash}`,
           e
         );
         return false;

--- a/actions/test/run_local.ts
+++ b/actions/test/run_local.ts
@@ -190,7 +190,6 @@ async function processBlock(
       };
 
       // run action
-      console.log(`[run_local] Run "addContract" action for TX ${hash}`);
       const result = await testRuntime
         .execute(addContract, testTransactionEvent)
         .then(() => true)

--- a/actions/test/run_local.ts
+++ b/actions/test/run_local.ts
@@ -17,6 +17,9 @@ import { exit } from "process";
 import { SupportedChainId } from "@cowprotocol/cow-sdk";
 import { ComposableCoW__factory } from "../types/factories/ComposableCoW__factory";
 
+const ERROR_CODE_PROCESS_BLOCK = 100;
+const ERROR_CODE_PROCESS_TX = 101;
+
 require("dotenv").config();
 
 const DEFAULT_PAGE_SIZE = 5000;
@@ -49,9 +52,9 @@ const main = async () => {
       `[run_local] Processing ONCE for a specific transaction: ${txEnv}...`
     );
 
-    await processTx(provider, txEnv, chainId, testRuntime).catch(() => {
-      exit(101);
-    });
+    await processTx(provider, txEnv, chainId, testRuntime).catch(() =>
+      exit(ERROR_CODE_PROCESS_TX)
+    );
 
     console.log(`[run_local] Transaction ${txEnv} has been processed.`);
   } else if (blockNumberEnv && !contractAddressEnv) {
@@ -66,10 +69,8 @@ const main = async () => {
         isLatest ? `latest (${blockNumber})` : blockNumber
       }...`
     );
-    await processBlock(provider, blockNumber, chainId, testRuntime).catch(
-      () => {
-        exit(100);
-      }
+    await processBlock(provider, blockNumber, chainId, testRuntime).catch(() =>
+      exit(ERROR_CODE_PROCESS_BLOCK)
     );
     console.log(`[run_local] Block ${blockNumber} has been processed.`);
   } else if (!blockNumberEnv && !contractAddressEnv) {

--- a/actions/utils/poll.ts
+++ b/actions/utils/poll.ts
@@ -7,7 +7,7 @@ import {
 } from "@cowprotocol/cow-sdk";
 
 // Watch-tower will index every block, so we will by default the processing block and not the latest.
-const POLL_FROM_LATEST_BLOCK = true;
+const POLL_FROM_LATEST_BLOCK = false;
 
 const ordersFactory = new ConditionalOrderFactory(
   DEFAULT_CONDITIONAL_ORDER_REGISTRY

--- a/actions/utils/poll.ts
+++ b/actions/utils/poll.ts
@@ -6,6 +6,9 @@ import {
   PollResult,
 } from "@cowprotocol/cow-sdk";
 
+// Watch-tower will index every block, so we will by default the processing block and not the latest.
+const POLL_FROM_LATEST_BLOCK = true;
+
 const ordersFactory = new ConditionalOrderFactory(
   DEFAULT_CONDITIONAL_ORDER_REGISTRY
 );
@@ -19,6 +22,16 @@ export async function pollConditionalOrder(
   if (!order) {
     return undefined;
   }
-  console.log(`[polling] Polling for ${order.toString()}....`);
-  return order.poll(pollParams);
+  const actualPollParams = POLL_FROM_LATEST_BLOCK
+    ? { ...pollParams, blockInfo: undefined }
+    : pollParams;
+
+  console.log(
+    `[polling] Polling for ${order.toString()} using block (${
+      actualPollParams.blockInfo === undefined
+        ? "latest"
+        : actualPollParams.blockInfo.blockNumber
+    })....`
+  );
+  return order.poll(actualPollParams);
 }

--- a/tenderly.yaml
+++ b/tenderly.yaml
@@ -8,6 +8,7 @@ actions:
     specs:
       register_single_order:
         description: Listens to events that index new single conditional orders
+        execution_type: sequential
         function: addContract:addContract
         trigger:
           transaction:
@@ -27,6 +28,7 @@ actions:
 
       register_merkle_root:
         description: Listens to events that index a merkle root of conditional orders
+        execution_type: sequential
         function: addContract:addContract
         trigger:
           transaction:
@@ -46,6 +48,7 @@ actions:
 
       watch_settlements:
         description: Watch for settled trades and update the state
+        execution_type: sequential
         function: checkForSettlement:checkForSettlement
         trigger:
           transaction:
@@ -67,6 +70,7 @@ actions:
         description:
           Checks on every block if the registered smart order contract
           wants to trade
+        execution_type: sequential
         function: checkForAndPlaceOrder:checkForAndPlaceOrder
         trigger:
           block:


### PR DESCRIPTION
# Description
After reviewing the logs, and the cases pointed out by @mfw78 on unindexed order I created this PR to:
- Improve logging
- Make it easier to re-process an order for a given TX


## Reduced error messages
Handled errors are not errors :) 
So for example, if the order is already orderbook and we just need to wait, is not an error. So i reduced to WARN those messages.

This hopefully will let us filter the errors in the day and reduce the noise.

See https://github.com/cowprotocol/tenderly-watch-tower/pull/32/files#diff-8e2dc90f4a6ebdf01f8603707f37f7794972fdf1827102bfce89497804f72837R185

## Allow to re-process a TX
Now you can easily debug cases of TX that create orders by adding the TX hash in the `.env`

This is way faster for debugging cases, since processing a whole block is very slow (process 100-200tx!)

https://github.com/cowprotocol/tenderly-watch-tower/pull/32/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR19

## Reduced messages

Don't write messages that don't add a lot of value:
https://github.com/cowprotocol/tenderly-watch-tower/pull/32/files#diff-5d3bc67362ae1598162466e069b336740bfdb4f706d88e8057b0e85132210438R72


## Let addContract log the TX
When debugging in the logs is convenient to search by blockNumber or hash.

`checkForAndPlaceOrder` already logs the TX, but not the `addContract`. 
It was hard to find a specific order. So this PR adds the TX and block into the logs

https://github.com/cowprotocol/tenderly-watch-tower/pull/32/files#diff-5d3bc67362ae1598162466e069b336740bfdb4f706d88e8057b0e85132210438R147



## Force SEQUENTIAL execution
Its a requirement for this project right now, so i made it explicit:
https://github.com/cowprotocol/tenderly-watch-tower/pull/32/files#diff-e3185fd2787bf4c6056698f3a82e0403ada878137d9d82346d3d1d12c2640556R11