### PR TITLE
Schedule not balance orders + fix issue with no due orders

### DIFF
--- a/actions/checkForAndPlaceOrder.ts
+++ b/actions/checkForAndPlaceOrder.ts
@@ -119,10 +119,12 @@ const _checkForAndPlaceOrder: ActionFn = async (
       // Check if the order is due (by epoch)
       if (
         lastResult?.result === PollResultCode.TRY_AT_EPOCH &&
-        lastResult.epoch < blockTimestamp
+        blockTimestamp < lastResult.epoch
       ) {
         console.log(
-          `${logPrefix} Skipping conditional. Reason: Not due yet (TRY_AT_EPOCH=${lastResult.epoch}). ${logOrderDetails}`,
+          `${logPrefix} Skipping conditional. Reason: Not due yet (TRY_AT_EPOCH=${
+            lastResult.epoch
+          }, ${formatEpoch(lastResult.epoch)}). ${logOrderDetails}`,
           conditionalOrder.params
         );
         continue;
@@ -131,10 +133,14 @@ const _checkForAndPlaceOrder: ActionFn = async (
       // Check if the order is due (by blockNumber)
       if (
         lastResult?.result === PollResultCode.TRY_ON_BLOCK &&
-        lastResult.blockNumber < blockNumber
+        blockNumber < lastResult.blockNumber
       ) {
         console.log(
-          `${logPrefix} Skipping conditional. Reason: Not due yet (TRY_ON_BLOCK=${lastResult.blockNumber}). ${logOrderDetails}`,
+          `${logPrefix} Skipping conditional. Reason: Not due yet (TRY_ON_BLOCK=${
+            lastResult.blockNumber
+          }, in ${
+            lastResult.blockNumber - blockNumber
+          } blocks). ${logOrderDetails}`,
           conditionalOrder.params
         );
         continue;

--- a/actions/checkForAndPlaceOrder.ts
+++ b/actions/checkForAndPlaceOrder.ts
@@ -32,14 +32,14 @@ import {
 import { ChainContext, ConditionalOrder, OrderStatus } from "./model";
 import { pollConditionalOrder } from "./utils/poll";
 import {
+  OrderPostError,
   PollParams,
   PollResult,
   PollResultCode,
   PollResultErrors,
   PollResultSuccess,
-  PollResultTryNextBlock,
-  PollResultUnexpectedError,
   SupportedChainId,
+  formatEpoch,
 } from "@cowprotocol/cow-sdk";
 
 const GPV2SETTLEMENT = "0x9008D19f58AAbD9eD0D60971565AA8510560ab41";
@@ -53,6 +53,9 @@ const ORDER_BOOK_API_HANDLED_ERRORS = [
   "InsufficientAllowance",
   "InsufficientFee",
 ];
+
+const ApiErrors = OrderPostError.errorType;
+const WAITING_TIME_MINUTES_FOR_NOT_BALANCE = 10; // 10 min
 
 /**
  * Watch for new blocks and check for orders to place
@@ -339,12 +342,13 @@ async function _processConditionalOrder(
     // Place order, if the orderUid has not been submitted or filled
     if (!conditionalOrder.orders.has(orderUid)) {
       // Place order
-      const placeOrderResult = await _placeOrder(
+      const placeOrderResult = await _placeOrder({
         orderUid,
-        { ...orderToSubmit, from: owner, signature },
-        chainContext.apiUrl,
-        orderRef
-      );
+        order: { ...orderToSubmit, from: owner, signature },
+        apiUrl: chainContext.apiUrl,
+        blockTimestamp,
+        orderRef,
+      });
 
       // In case of error, return early
       if (placeOrderResult.result !== PollResultCode.SUCCESS) {
@@ -423,16 +427,15 @@ export const _printUnfilledOrders = (orders: Map<BytesLike, OrderStatus>) => {
  * @param order to be placed on the cow protocol api
  * @param apiUrl rest api url
  */
-async function _placeOrder(
-  orderUid: string,
-  order: any,
-  apiUrl: string,
-  orderRef: string
-): Promise<
-  | Omit<PollResultSuccess, "order" | "signature">
-  | PollResultTryNextBlock
-  | PollResultUnexpectedError
-> {
+async function _placeOrder(params: {
+  orderUid: string;
+  order: any;
+  apiUrl: string;
+  orderRef: string;
+  blockTimestamp: number;
+}): Promise<Omit<PollResultSuccess, "order" | "signature"> | PollResultErrors> {
+  const { orderUid, order, apiUrl, orderRef, blockTimestamp } = params;
+
   const logPrefix = `[placeOrder::${orderRef}]`;
   try {
     const postData = {
@@ -474,7 +477,12 @@ async function _placeOrder(
     if (error.response) {
       const { status, data } = error.response;
 
-      const handleErrorResult = _handleOrderBookError(status, data, error);
+      const handleErrorResult = _handleOrderBookError({
+        status,
+        data,
+        error,
+        blockTimestamp,
+      });
       const isSuccess = handleErrorResult.result === PollResultCode.SUCCESS;
 
       // The request was made and the server responded with a status code
@@ -510,19 +518,40 @@ async function _placeOrder(
   return { result: PollResultCode.SUCCESS };
 }
 
-function _handleOrderBookError(
-  status: any,
-  data: any,
-  error: any
-):
-  | Omit<PollResultSuccess, "order" | "signature">
-  | PollResultTryNextBlock
-  | PollResultUnexpectedError {
+function _handleOrderBookError(params: {
+  status: any;
+  data: any;
+  error: any;
+  blockTimestamp: number;
+}): Omit<PollResultSuccess, "order" | "signature"> | PollResultErrors {
+  const { status, data, error, blockTimestamp } = params;
   if (status === 400) {
     // The order is in the OrderBook, all good :)
-    if (data?.errorType === "DuplicatedOrder") {
+    if (data?.errorType === ApiErrors.DUPLICATE_ORDER) {
       return {
         result: PollResultCode.SUCCESS,
+      };
+    }
+
+    // It's possible that an order has not enough allowance or balance.
+    // Returning DONT_TRY_AGAIN would be to drastic, but we can give the WatchTower a break by scheduling next attempt in a few minutes
+    // This why, we don't so it doesn't try in every block
+    if (
+      [
+        ApiErrors.INSUFFICIENT_ALLOWANCE,
+        ApiErrors.INSUFFICIENT_BALANCE,
+      ].includes(data?.errorType)
+    ) {
+      const nextPollTimestamp =
+        blockTimestamp + WAITING_TIME_MINUTES_FOR_NOT_BALANCE * 60;
+      return {
+        result: PollResultCode.TRY_AT_EPOCH,
+        epoch: blockTimestamp + WAITING_TIME_MINUTES_FOR_NOT_BALANCE,
+        reason: `Not enough allowance/balance (${
+          data?.errorType
+        }). Scheduling next polling in ${WAITING_TIME_MINUTES_FOR_NOT_BALANCE} minutes, at ${nextPollTimestamp} ${formatEpoch(
+          nextPollTimestamp
+        )}`,
       };
     }
 

--- a/actions/checkForAndPlaceOrder.ts
+++ b/actions/checkForAndPlaceOrder.ts
@@ -55,7 +55,7 @@ const ORDER_BOOK_API_HANDLED_ERRORS = [
 ];
 
 const ApiErrors = OrderPostError.errorType;
-const WAITING_TIME_MINUTES_FOR_NOT_BALANCE = 10; // 10 min
+const WAITING_TIME_SECONDS_FOR_NOT_BALANCE = 10 * 60; // 10 min
 
 /**
  * Watch for new blocks and check for orders to place
@@ -549,15 +549,15 @@ function _handleOrderBookError(params: {
       ].includes(data?.errorType)
     ) {
       const nextPollTimestamp =
-        blockTimestamp + WAITING_TIME_MINUTES_FOR_NOT_BALANCE * 60;
+        blockTimestamp + WAITING_TIME_SECONDS_FOR_NOT_BALANCE;
       return {
         result: PollResultCode.TRY_AT_EPOCH,
-        epoch: blockTimestamp + WAITING_TIME_MINUTES_FOR_NOT_BALANCE,
+        epoch: nextPollTimestamp,
         reason: `Not enough allowance/balance (${
           data?.errorType
-        }). Scheduling next polling in ${WAITING_TIME_MINUTES_FOR_NOT_BALANCE} minutes, at ${nextPollTimestamp} ${formatEpoch(
-          nextPollTimestamp
-        )}`,
+        }). Scheduling next polling in ${Math.floor(
+          WAITING_TIME_SECONDS_FOR_NOT_BALANCE / 60
+        )} minutes, at ${nextPollTimestamp} ${formatEpoch(nextPollTimestamp)}`,
       };
     }
 

--- a/actions/test/run_local.ts
+++ b/actions/test/run_local.ts
@@ -52,9 +52,10 @@ const main = async () => {
       `[run_local] Processing ONCE for a specific transaction: ${txEnv}...`
     );
 
-    await processTx(provider, txEnv, chainId, testRuntime).catch(() =>
-      exit(ERROR_CODE_PROCESS_TX)
-    );
+    await processTx(provider, txEnv, chainId, testRuntime).catch((e) => {
+      console.error(e);
+      exit(ERROR_CODE_PROCESS_TX);
+    });
 
     console.log(`[run_local] Transaction ${txEnv} has been processed.`);
   } else if (blockNumberEnv && !contractAddressEnv) {
@@ -235,7 +236,7 @@ async function processTx(
 ) {
   let hasErrors = false;
   const transaction = await provider.getTransaction(tx);
-  if (!transaction.blockNumber) {
+  if (!transaction?.blockNumber) {
     throw new Error(`The transaction ${tx} is not mined yet (no blockNumber)`);
   }
   const block = await provider.getBlock(transaction.blockNumber);

--- a/actions/test/run_local.ts
+++ b/actions/test/run_local.ts
@@ -237,12 +237,9 @@ async function processTx(
   let hasErrors = false;
   const transaction = await provider.getTransaction(tx);
   if (!transaction?.blockNumber) {
-    throw new Error(`The transaction ${tx} is not mined yet (no blockNumber)`);
+    throw new Error(`The transaction ${tx} not found`);
   }
   const block = await provider.getBlock(transaction.blockNumber);
-  if (!transaction) {
-    throw new Error(`[run_local] Transaction ${tx} not found`);
-  }
 
   hasErrors ||= !(await _processTx(
     provider,

--- a/actions/utils/context.ts
+++ b/actions/utils/context.ts
@@ -66,9 +66,10 @@ async function _getSlack(
 
   // Init slack
   let slack;
-  const webhookUrl = await context.secrets
-    .get("SLACK_WEBHOOK_URL")
-    .catch(() => "");
+  const webhookUrl = (
+    await context.secrets.get("SLACK_WEBHOOK_URL").catch(() => "")
+  ).trim();
+
   if (!notificationsEnabled) {
     return undefined;
   }

--- a/actions/utils/context.ts
+++ b/actions/utils/context.ts
@@ -253,7 +253,5 @@ async function _initLogging(
   ).trim();
   if (logglyToken) {
     initLogging(logglyToken, [transactionName, `chain_${chainId}`]);
-  } else {
-    console.warn("LOGGLY_TOKEN is not set, logging to console only");
   }
 }

--- a/actions/utils/context.ts
+++ b/actions/utils/context.ts
@@ -247,7 +247,9 @@ async function _initLogging(
   chainId: SupportedChainId,
   context: Context
 ) {
-  const logglyToken = await context.secrets.get("LOGGLY_TOKEN").catch(() => "");
+  const logglyToken = (
+    await context.secrets.get("LOGGLY_TOKEN").catch(() => "")
+  ).trim();
   if (logglyToken) {
     initLogging(logglyToken, [transactionName, `chain_${chainId}`]);
   } else {


### PR DESCRIPTION
# Description

This PR is an attempt to handle cases when the orders don't have enough balance or allowance better


## Reduce the checks
Because is a run-time error, we will actually re-attempt in next block. 

This will create an error in the logs every 15seconds!
Further more, we will be consuming RPC calls, and punish the API trying to post orders that are unbacked!

This PR will handle this case, and schedule next poll only after 10 minutes (this should reduce errors and calls by `50x` and still give the user a chance to add the balance and allowance to get their order back on track)

This handling is less drastic than the alternative that would be to return a `DONT_TRY_AGAIN`.

## Fix issue with not due orders
While reviewing the logs after these cleanups, i realised the condition was flipped! so we were ignoring orders that should be checked. 

This PR also fixes this. 

## Improve logs
This case will be nicely logged

![image](https://github.com/cowprotocol/tenderly-watch-tower/assets/2352112/3b73662c-82ec-4757-a4d6-be85ad1adfae)



## Misc
Additionally, now we use an enum for the errors instead of hardcoded strings


<img width="1617" alt="image" src="https://github.com/cowprotocol/tenderly-watch-tower/assets/2352112/e5fd951e-e6a9-4373-951d-4121675fc8a5">

## Handle case: Don't show as ERROR
- Before this PR they show as unhandled ERROR, since we actually try to post them to the API and we get a run-time error
- After this PR it will log them as WARN


# Context

https://cowservices.slack.com/archives/C05RMJB7ZFA/p1695308323236179