### PR TITLE
refactor: context

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@sentry/node": "^7.64.0",
     "axios": "^1.4.0",
     "ethers": "^5.7.2",
-    "exponential-backoff": "^3.1.1",
     "graphql-request": "^6.1.0",
     "level": "^8.0.0",
     "level-ts": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "prepare": "husky install && yarn typechain"
   },
   "devDependencies": {
-    "@commander-js/extra-typings": "^11.0.0",
     "@commitlint/cli": "^17.6.7",
     "@commitlint/config-conventional": "^17.6.7",
     "@typechain/ethers-v5": "^10.2.0",
@@ -40,6 +39,7 @@
     "typechain": "^8.1.1"
   },
   "dependencies": {
+    "@commander-js/extra-typings": "^11.0.0",
     "@cowprotocol/contracts": "^1.4.0",
     "@cowprotocol/cow-sdk": "^3.0.0-rc.9",
     "@sentry/integrations": "^7.64.0",

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -1,14 +1,13 @@
 import Slack = require("node-slack");
 
 import { Transaction as SentryTransaction } from "@sentry/node";
-import { BytesLike, ethers } from "ethers";
+import { BytesLike } from "ethers";
 
-import { apiUrl } from "../utils";
 import type {
   ConditionalOrderCreatedEvent,
   IConditionalOrder,
 } from "./generated/ComposableCoW";
-import { PollResult, SupportedChainId } from "@cowprotocol/cow-sdk";
+import { PollResult } from "@cowprotocol/cow-sdk";
 import DBService from "../utils/db";
 
 // Standardise the storage key
@@ -104,7 +103,7 @@ export class Registry {
   /**
    * Instantiates a registry.
    * @param ownerOrders What map to populate the registry with
-   * @param storage interface to the Tenderly storage
+   * @param storage storage service to use
    * @param network Which network the registry is for
    */
   constructor(
@@ -230,28 +229,6 @@ export class Registry {
 
   public stringifyOrders(): string {
     return JSON.stringify(this.ownerOrders, replacer);
-  }
-}
-
-export class ChainContext {
-  provider: ethers.providers.Provider;
-  apiUrl: string;
-  chainId: SupportedChainId;
-
-  constructor(
-    provider: ethers.providers.Provider,
-    apiUrl: string,
-    chainId: SupportedChainId
-  ) {
-    this.provider = provider;
-    this.apiUrl = apiUrl;
-    this.chainId = chainId;
-  }
-
-  public static async create(url: string): Promise<ChainContext> {
-    const provider = new ethers.providers.JsonRpcProvider(url);
-    const chainId = (await provider.getNetwork()).chainId;
-    return new ChainContext(provider, apiUrl(chainId), chainId);
   }
 }
 


### PR DESCRIPTION
# Description
Given that now the code has contexts which change across different chains, it's important to be careful about distinguishing this.

# Changes

- [x] Converged on using `ChainContext` class that contains all data for that chain.
- [x] Passes `this` down the code path for retrieval of providers, chainId etc.
- [x] Did some gardening removing storage back-off (now using storage with known transaction locking, so can fail, killing the container). 

## How to test

Confirm sync still works from genesis:

```bash
docker run -v ./database:/usr/src/app/database -it watchtower run --rpc http://172.33.0.6:8545 --rpc http://172.33.0.5:8545 --deployment-block 17883049 --deployment-block 29389123 --page-size 0 --one-shot true
```

## Related Issues

Closes #50 