### PR TITLE
feat: `dump-db` command

### DIFF
--- a/src/commands/dumpDb.ts
+++ b/src/commands/dumpDb.ts
@@ -11,7 +11,7 @@ export async function dumpDb(options: DumpDbOptions) {
   Registry.dump(DBService.getInstance(), chainId.toString())
     .then((dump) => console.log(dump))
     .catch((error) => {
-      console.error(error);
+      console.error("Error dumping DB", error);
       process.exit(1);
     });
 }

--- a/src/commands/dumpDb.ts
+++ b/src/commands/dumpDb.ts
@@ -1,0 +1,17 @@
+import { DumpDbOptions, Registry } from "../types";
+import { DBService } from "../utils";
+
+/**
+ * Dump the database as JSON to STDOUT for a given chain ID
+ * @param options A dict, but essentially just the chainId
+ */
+export async function dumpDb(options: DumpDbOptions) {
+  const { chainId } = options;
+
+  Registry.dump(DBService.getInstance(), chainId.toString())
+    .then((dump) => console.log(dump))
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,3 +1,4 @@
 export * from "./run";
 export * from "./replayBlock";
 export * from "./replayTx";
+export * from "./dumpDb";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { program, Option } from "@commander-js/extra-typings";
 import { ReplayTxOptions } from "./types";
-import { replayBlock, replayTx, run } from "./commands";
+import { dumpDb, replayBlock, replayTx, run } from "./commands";
 
 async function main() {
   program
@@ -61,6 +61,21 @@ async function main() {
 
       // Run the watchtower
       run({ ...options, deploymentBlock, pageSize });
+    });
+
+  program
+    .command("dump-db")
+    .description("Dump database as JSON to STDOUT")
+    .requiredOption("--chain-id <chainId>", "Chain ID to dump")
+    .action((options) => {
+      // Ensure that the chain ID is a number
+      const chainId = Number(options.chainId);
+      if (isNaN(chainId)) {
+        throw new Error("Chain ID must be a number");
+      }
+
+      // Dump the database
+      dumpDb({ chainId });
     });
 
   program

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,10 @@ export interface ReplayTxOptions extends WatchtowerReplayOptions {
   tx: string;
 }
 
+export interface DumpDbOptions {
+  chainId: number;
+}
+
 export * from "./model";
 export * from "./generated";
 export * from "./generated/ComposableCoW";

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -131,7 +131,7 @@ export class Registry {
     network: string
   ): Promise<string> {
     const ownerOrders = await loadOwnerOrders(storage, network);
-    return JSON.stringify(ownerOrders, replacer);
+    return JSON.stringify(ownerOrders, replacer, 2);
   }
 
   /**
@@ -146,9 +146,9 @@ export class Registry {
     genesisBlockNumber: number
   ): Promise<Registry> {
     const db = storage.getDB();
-    const ownerOrders = await loadOwnerOrders(storage, network)
-      .then((orders) => orders)
-      .catch(() => createNewOrderMap());
+    const ownerOrders = await loadOwnerOrders(storage, network).catch(() =>
+      createNewOrderMap()
+    );
     const lastNotifiedError = await db
       .get(getNetworkStorageKey(LAST_NOTIFIED_ERROR_STORAGE_KEY, network))
       .then((isoDate: string | number | Date) =>

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -146,7 +146,9 @@ export class Registry {
     genesisBlockNumber: number
   ): Promise<Registry> {
     const db = storage.getDB();
-    const ownerOrders = await loadOwnerOrders(storage, network);
+    const ownerOrders = await loadOwnerOrders(storage, network)
+      .then((orders) => orders)
+      .catch(() => createNewOrderMap());
     const lastNotifiedError = await db
       .get(getNetworkStorageKey(LAST_NOTIFIED_ERROR_STORAGE_KEY, network))
       .then((isoDate: string | number | Date) =>
@@ -285,7 +287,11 @@ function parseConditionalOrders(
   _version: number | undefined
 ): Map<Owner, Set<ConditionalOrder>> {
   if (!serializedConditionalOrders) {
-    return new Map<Owner, Set<ConditionalOrder>>();
+    return createNewOrderMap();
   }
   return JSON.parse(serializedConditionalOrders, _reviver);
+}
+
+function createNewOrderMap(): Map<Owner, Set<ConditionalOrder>> {
+  return new Map<Owner, Set<ConditionalOrder>>();
 }


### PR DESCRIPTION
# Description
This PR adds a dump-db command feature to meet the requirements for analysing inter-watch-tower performance.

# Changes

- [x] Add `dump-db` command.
- [x] Dry `Registry` code for loading orders.

## How to test

1. Test with no database (confirm create keys).
2. Test with existing database (confirm loads keys correctly).

## Related Issues

Fixes #48 